### PR TITLE
Add a method to remove all hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Hooks system for the Eloquent ORM (Laravel 5.1+ LTS).
 
-Hooks are available fro the following methods:
+Hooks are available for the following methods:
 
 * `Model::getAttribute`
 * `Model::setAttribute`
@@ -27,6 +27,8 @@ composer require sofa/hookable:~1.0
 ## Usage
 
 In order to register a hook you use static method `hook` on the model: [example](https://github.com/jarektkaczyk/eloquence/blob/5.1/src/Mappable.php#L42-L56).
+
+To remove all hooks from a model use the static method `flushHooks`.
 
 **Important** Due to the fact that PHP will not let you bind a `Closure` to your model's instance if it is created **in a static context** (for example model's `boot` method), you need to hack it a little bit, in that the closure is created in an object context. 
 

--- a/spec/HookableSpec.php
+++ b/spec/HookableSpec.php
@@ -18,4 +18,25 @@ describe('Sofa\Hookable\Hookable', function () {
         expect($hookable)->toReceive('instanceMethod');
         $hookable->getAttribute('attribute');
     });
+
+    it('flushes all hooks with the flushHooks method', function () {
+        $parent = Stub::classname();
+
+        $hookableClass = Stub::classname(['uses' => Hookable::class, 'extends' => $parent]);
+        $hookableClass::hook('method1', function ($next, $value, $args) {});
+        $hookableClass::hook('method2', function ($next, $value, $args) {});
+
+        $reflectedClass = new ReflectionClass($hookableClass);
+        $reflectedProperty = $reflectedClass->getProperty('hooks');
+        $reflectedProperty->setAccessible(true);
+
+        $hooks = $reflectedProperty->getValue();
+        expect($hooks)->toHaveLength(2);
+
+        $hookableClass::flushHooks();
+
+        $hooks = $reflectedProperty->getValue();
+        expect($hooks)->toHaveLength(0);
+    });
+
 });

--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -30,6 +30,16 @@ trait Hookable
     }
 
     /**
+     * Remove all of the hooks on the Eloquent model.
+     *
+     * @return void
+     */
+    public static function flushHooks()
+    {
+        static::$hooks = [];
+    }
+
+    /**
      * Create new Hookable query builder for the instance.
      *
      * @param  \Illuminate\Database\Query\Builder


### PR DESCRIPTION
This change adds a *flushHooks* method to the trait, which removes all of the hooks from the model.

I added this because when running unit tests on models using the *Mappable* trait from <https://github.com/jarektkaczyk/eloquence> the hooks are repeatedly added and after running a number of tests eventually the call stack grows to a point where it exceeds the [xdebug maximum depth](http://xdebug.org/docs/all_settings#var_display_max_depth) causing the tests to crash. This can be circumvented by flushing the hooks in the *TestCase* *setUp* method, or by calling it before adding the hooks in *Mappable's* *bootMappable* method.