### PR TITLE
Fix for Laravel 5.2

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -438,9 +438,10 @@ class Builder extends EloquentBuilder
      * Get a single column's value from the first result of a query.
      *
      * @param  string  $column
+     * @param  string  $key
      * @return mixed
      */
-    public function pluck($column)
+    public function pluck($column, $key = null)
     {
         return $this->value($column);
     }


### PR DESCRIPTION
In Laravel 5.2 the pluck function expects an extra parameter. 

```
Declaration of Sofa\Hookable\Builder::pluck($column) should be compatible with Illuminate\Database\Eloquent\Builder::pluck($column, $key = NULL)
```

PS: This is my first pull request ever. I hope it is according to the contribution rules.