### PR TITLE
fix: missing PHPDoc

### DIFF
--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -178,6 +178,8 @@ trait Hookable
     /**
      * Register hook for replicate.
      *
+     * @param array|null $except
+     *
      * @return mixed
      */
     public function replicate(array $except = null)


### PR DESCRIPTION
Added a missing PHPDoc `@return` annotation