### PR TITLE
Use a minimal version instead of a fixed one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/database": "5.3.*|5.4.*"
+        "illuminate/database": "^5.3"
     },
     "require-dev": {
         "crysalead/kahlan": "~1.1"


### PR DESCRIPTION
By using the `^` flag, you ask for `illuminate/database` that is AT LEAST v5.3.