### PR TITLE
Changing logic of isDirty to match with Laravel 5.5 and prevent from always returning false

### DIFF
--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -139,10 +139,10 @@ trait Hookable
     /**
      * Register hook for isDirty.
      *
-     * @param null $attributes
+     * @param array $attributes
      * @return bool
      */
-    public function isDirty($attributes = null)
+    public function isDirty($attributes = [])
     {
         if (! is_array($attributes) && !is_null($attributes)) {
             $attributes = func_get_args();

--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -144,7 +144,7 @@ trait Hookable
      */
     public function isDirty($attributes = null)
     {
-        if (! is_array($attributes) && !is_null($attributes)) {
+        if (! is_array($attributes)) {
             $attributes = func_get_args();
         }
 

--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -139,10 +139,10 @@ trait Hookable
     /**
      * Register hook for isDirty.
      *
-     * @param array $attributes
+     * @param null $attributes
      * @return bool
      */
-    public function isDirty($attributes = [])
+    public function isDirty($attributes = null)
     {
         if (! is_array($attributes) && !is_null($attributes)) {
             $attributes = func_get_args();


### PR DESCRIPTION
This fixes https://github.com/jarektkaczyk/hookable/issues/15.

This PR changes the if statement in `isDirty` so that an empty array will be passed in when no arguments are specified, so `hasChanges` works properly. I have tested the changes and they fix the issue and allow model update operations to function again.

See https://github.com/laravel/framework/pull/20130 for what was changed in Laravel 5.5 as it relates to `isDirty`. We now need to pass in an array instead of allowing null as hasChanges() in `Illuminate\Database\Eloquent\Concerns\HasAttributes` is checking for an empty array instead of null. This package's `isDirty` was effectively doing `parent::isDirty(null);` with the default argument, so `func_get_args()` inside Laravel's `isDirty` was returning `[null]` and screwing everything up.