### PR TITLE
Add group by mapping support

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -62,7 +62,7 @@ class Builder extends EloquentBuilder
      */
     protected function callHook($method, ArgumentBag $args)
     {
-        if ($this->hasHook($args->get('column')) || in_array($method, ['select', 'addSelect'])) {
+        if ($this->hasHook($args->get('column')) || in_array($method, ['select', 'addSelect', 'groupBy'])) {
             return $this->getModel()->queryHook($this, $method, $args);
         }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -400,6 +400,17 @@ class Builder extends EloquentBuilder
     }
 
     /**
+     * Add a "group by" clause to the query.
+     *
+     * @param  array  ...$groups
+     * @return $this
+     */
+    public function groupBy(...$groups)
+    {
+      return $this->callHook(__FUNCTION__, $this->packArgs(compact('groups')));
+    }
+
+    /**
      * Add an "order by" clause to the query.
      *
      * @param  string  $column


### PR DESCRIPTION
This adds support for translating column names when they are used in a groupBy call.

Related PRs:
Hookable: `https://github.com/jarektkaczyk/hookable/pull/21`
Mappable: `https://github.com/jarektkaczyk/eloquence-mappable/pull/3`