### PR TITLE
return model to match default behaviour of eloquent

### DIFF
--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -100,7 +100,7 @@ trait Hookable
      *
      * @param  string $key
      * @param  mixed  $value
-     * @return void
+     * @return mixed
      */
     public function setAttribute($key, $value)
     {
@@ -111,7 +111,9 @@ trait Hookable
             parent::setAttribute($key, $value);
         };
 
-        return $this->pipe($hooks, $payload, $params, $destination);
+        $this->pipe($hooks, $payload, $params, $destination);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
As mentioned here https://github.com/jarektkaczyk/hookable/issues/22, I believe `setAttribute` should return the current object to match the default behaviour of eloquent:
https://github.com/laravel/framework/blob/5.7/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L550-L587