### PR TITLE
Fix Parameter Grouping with Laravel 7.x

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -124,7 +124,7 @@ class Builder extends EloquentBuilder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if (!in_array(strtolower($operator), $this->operators, true)) {
+        if (! $column instanceof Closure && !in_array(strtolower($operator), $this->operators, true)) {
             list($value, $operator) = [$operator, '='];
         }
 


### PR DESCRIPTION
Laravel 7.x introduced the following change https://github.com/laravel/framework/pull/30934 allowing for the feature https://laravel.com/docs/7.x/queries#subquery-where-clauses

This currently breaks parameter grouping when using eloquence due to the where() function passing `=` as the default operator even if a closure is passed.

This MR aims to fix the issue by detecting if a closure is passed and if so, not applying the default `=` operator.

To replicate the bug using sample Code on a fresh Laravel 7 install with sofa/eloquence-base:

app/User.php

```
<?php

namespace App;

use Illuminate\Contracts\Auth\MustVerifyEmail;
use Illuminate\Foundation\Auth\User as Authenticatable;
use Illuminate\Notifications\Notifiable;
use Sofa\Eloquence\Eloquence;

class User extends Authenticatable
{
    use Notifiable, Eloquence;

    protected $fillable = [
        'name', 'email', 'password',
    ];

    protected $hidden = [
        'password', 'remember_token',
    ];

    protected $casts = [
        'email_verified_at' => 'datetime',
    ];
}
```

routes/web.php

```
Route::get('/', function () {

    App\User::where(function ($query) {
        $query->whereNull('remember_token')
              ->orWhere('email','!=','test@test.com');
    })->get();

});
```

Results in the error

```
Illuminate\Database\QueryException
SQLSTATE[HY000]: General error: 1096 No tables used (SQL: select * from `users` where (select * where `remember_token` is null or `email` != test@test.com) is null)
```
