### PR TITLE
Fix callParent method on php 8

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,7 +50,7 @@ class Builder extends EloquentBuilder
      */
     public function callParent($method, array $args)
     {
-        return call_user_func_array("parent::{$method}", $args);
+        return parent::$method(...array_values($args));
     }
 
     /**


### PR DESCRIPTION
The `call_user_func_array` function has been slightly changed on PHP 8 — it supports named arguments now and interprets assoc arrays like them.
Also, calling parent methods now for some reason doesn't work this way.