### PR TITLE
[FIX] Infinity loop with PHP 8.1

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,7 +50,7 @@ class Builder extends EloquentBuilder
      */
     public function callParent($method, array $args)
     {
-        return call_user_func_array("parent::{$method}", $args);
+        return call_user_func_array(['parent', $method], $args);
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,7 +50,7 @@ class Builder extends EloquentBuilder
      */
     public function callParent($method, array $args)
     {
-        return call_user_func_array(['parent', $method], $args);
+        return parent::$method(...array_values($args));
     }
 
     /**


### PR DESCRIPTION
The only problem I found after upgrading PHP from PHP 7.4 to 8.1 was the infinite loop.

It is enough to change the way the method is called. Previously, a method that was supposed to refer to parent referred to itself.